### PR TITLE
Make `Graph` a generic view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
 dependencies = [
  "async-lock 2.8.0",
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "concurrent-queue",
  "futures-lite 1.13.0",
  "log",
@@ -245,7 +245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65"
 dependencies = [
  "async-lock 3.3.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "concurrent-queue",
  "futures-io",
  "futures-lite 2.2.0",
@@ -287,7 +287,7 @@ dependencies = [
  "async-lock 2.8.0",
  "async-signal",
  "blocking",
- "cfg-if",
+ "cfg-if 1.0.0",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
  "rustix 0.38.31",
@@ -314,7 +314,7 @@ dependencies = [
  "async-io 2.3.1",
  "async-lock 2.8.0",
  "atomic-waker",
- "cfg-if",
+ "cfg-if 1.0.0",
  "futures-core",
  "futures-io",
  "rustix 0.38.31",
@@ -410,7 +410,7 @@ checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object",
@@ -527,6 +527,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -626,7 +632,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen",
 ]
 
@@ -723,7 +729,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -823,6 +829,7 @@ dependencies = [
 name = "cyma"
 version = "0.1.0"
 dependencies = [
+ "len-trait",
  "nih_plug",
  "nih_plug_vizia",
  "num-traits",
@@ -1212,7 +1219,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1241,7 +1248,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -1252,7 +1259,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
@@ -1434,7 +1441,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -1528,6 +1535,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "len-trait"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723558ab8acaa07cb831b424cd164b587ddc1648b34748a30953c404e9a4a65b"
+dependencies = [
+ "cfg-if 0.1.10",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,7 +1555,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "winapi",
 ]
 
@@ -1742,7 +1758,7 @@ dependencies = [
  "atomic_refcell",
  "backtrace",
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "clap-sys",
  "core-foundation",
  "crossbeam",
@@ -1798,7 +1814,7 @@ checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
 dependencies = [
  "bitflags 1.3.2",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset 0.6.5",
 ]
@@ -1810,7 +1826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset 0.6.5",
 ]
@@ -1822,7 +1838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset 0.7.1",
 ]
@@ -2004,7 +2020,7 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall 0.4.1",
  "smallvec",
@@ -2155,7 +2171,7 @@ checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "concurrent-queue",
  "libc",
  "log",
@@ -2169,7 +2185,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30054e72317ab98eddd8561db0f6524df3367636884b7b21b703e4b280a84a14"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "concurrent-queue",
  "pin-project-lite",
  "rustix 0.38.31",
@@ -2549,7 +2565,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
 ]
@@ -2663,7 +2679,7 @@ version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand 2.0.1",
  "rustix 0.38.31",
  "windows-sys 0.52.0",
@@ -3144,7 +3160,7 @@ version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "Composable views and associated data structures for nih-plug UIs 
 nih_plug_vizia = { git = "https://github.com/robbert-vdh/nih-plug.git" }
 nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git" }
 num-traits = "0.2.18"
+len-trait = "0.6.1"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/src/utils/buffers/peak_buffer.rs
+++ b/src/utils/buffers/peak_buffer.rs
@@ -1,3 +1,4 @@
+use len_trait::len::{Empty, Len};
 use nih_plug::buffer::Buffer;
 use num_traits::real::Real;
 use std::{
@@ -114,6 +115,18 @@ impl<'a, T: Copy> IntoIterator for &'a PeakBuffer<T> {
 impl<T: Debug + Copy> Debug for PeakBuffer<T> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
         self.buffer.fmt(f)
+    }
+}
+
+impl<T> Empty for PeakBuffer<T> {
+    fn is_empty(self: &Self) -> bool {
+        self.buffer.is_empty()
+    }
+}
+impl<T> Len for PeakBuffer<T> {
+    /// Returns the length of the buffer.
+    fn len(self: &Self) -> usize {
+        self.buffer.len()
     }
 }
 

--- a/src/utils/buffers/ring_buffer.rs
+++ b/src/utils/buffers/ring_buffer.rs
@@ -1,6 +1,6 @@
-use std::fmt::Formatter;
-
+use len_trait::len::{Empty, Len};
 use std::fmt::Debug;
+use std::fmt::Formatter;
 use std::ops::{Deref, DerefMut, Index, IndexMut};
 
 /// A buffer that stores elements of type `T` in a First-In-First-Out manner.
@@ -147,11 +147,6 @@ impl<T: Default + Copy + Debug> RingBuffer<T> {
         self.head = (self.head + 1) % self.size;
     }
 
-    /// Returns the length of the buffer.
-    pub fn len(self: &Self) -> usize {
-        self.size
-    }
-
     /// Clears the entire buffer, filling it with default values (usually 0)
     pub fn clear(self: &mut Self) {
         self.data.iter_mut().for_each(|x| *x = T::default());
@@ -175,6 +170,18 @@ impl<'a, T: Copy> IntoIterator for &'a RingBuffer<T> {
             index: 0,
             index_back: self.size,
         }
+    }
+}
+
+impl<T> Empty for RingBuffer<T> {
+    fn is_empty(self: &Self) -> bool {
+        self.size == 0
+    }
+}
+impl<T> Len for RingBuffer<T> {
+    /// Returns the length of the buffer.
+    fn len(self: &Self) -> usize {
+        self.size
     }
 }
 

--- a/src/utils/buffers/waveform_buffer.rs
+++ b/src/utils/buffers/waveform_buffer.rs
@@ -1,5 +1,6 @@
 use crate::utils::ring_buffer::{Iter, RingBuffer};
 
+use len_trait::len::{Empty, Len};
 use nih_plug::buffer::Buffer;
 use num_traits::real::Real;
 use std::{
@@ -172,6 +173,18 @@ impl<T> Index<usize> for WaveformBuffer<T> {
 impl<T> IndexMut<usize> for WaveformBuffer<T> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         self.buffer.index_mut(index)
+    }
+}
+
+impl<T> Empty for WaveformBuffer<T> {
+    fn is_empty(self: &Self) -> bool {
+        self.buffer.is_empty()
+    }
+}
+impl<T> Len for WaveformBuffer<T> {
+    /// Returns the length of the buffer.
+    fn len(self: &Self) -> usize {
+        self.buffer.len()
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,3 +3,84 @@
 mod buffers;
 
 pub use buffers::*;
+use nih_plug::util::{db_to_gain, gain_to_db_fast};
+use nih_plug_vizia::vizia::binding::Res;
+use nih_plug_vizia::vizia::context::{Context, EventContext};
+use nih_plug_vizia::vizia::entity::Entity;
+
+/// Analogous to VIZIA's own ValueScaling.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ValueScaling {
+    Linear,
+    Power(f32),
+    Frequency,
+    Decibels,
+}
+
+impl ValueScaling {
+    pub fn normalized_to_value(&self, normalized: f32, min: f32, max: f32) -> f32 {
+        if normalized <= 0.0 {
+            return min;
+        } else if normalized >= 1.0 {
+            return max;
+        }
+
+        let map = |x: f32| -> f32 { (x * (max - min)) + min };
+
+        match self {
+            ValueScaling::Linear => map(normalized),
+
+            ValueScaling::Power(exponent) => map(normalized.powf(*exponent)),
+
+            ValueScaling::Frequency => {
+                let minl = min.log2();
+                let range = max.log2() - minl;
+                2.0f32.powf((normalized * range) + minl)
+            }
+
+            ValueScaling::Decibels => map(db_to_gain(normalized)),
+        }
+    }
+
+    pub fn value_to_normalized(&self, value: f32, min: f32, max: f32) -> f32 {
+        if value <= min {
+            return 0.0;
+        } else if value >= max {
+            return 1.0;
+        }
+
+        let unmap = |x: f32| -> f32 { (x - min) / (max - min) };
+
+        match self {
+            ValueScaling::Linear => unmap(value),
+
+            ValueScaling::Power(exponent) => unmap(value).powf(1.0 / *exponent),
+
+            ValueScaling::Frequency => {
+                let minl = min.log2();
+                let range = max.log2() - minl;
+                (value.log2() - minl) / range
+            }
+
+            ValueScaling::Decibels => unmap(gain_to_db_fast(value)),
+        }
+        .clamp(0., 1.)
+    }
+}
+
+// We can't use impl_res_simple!() since we're using nih_plug's version of VIZIA
+impl Res<ValueScaling> for ValueScaling {
+    fn get_val(&self, _: &Context) -> ValueScaling {
+        *self
+    }
+
+    fn set_or_bind<F>(&self, cx: &mut Context, entity: Entity, closure: F)
+    where
+        F: 'static + Fn(&mut EventContext, Self),
+    {
+        cx.with_current(entity, |cx| {
+            let cx = &mut EventContext::new_with_current(cx, entity);
+            (closure)(cx, *self);
+        });
+    }
+}

--- a/src/visualizers/graph.rs
+++ b/src/visualizers/graph.rs
@@ -1,6 +1,9 @@
-use std::sync::{Arc, Mutex};
+use len_trait::len::Len;
+use std::{
+    ops::Index,
+    sync::{Arc, Mutex},
+};
 
-use crate::utils::PeakBuffer;
 use nih_plug_vizia::vizia::{
     binding::{Lens, LensExt, Res},
     context::{Context, DrawContext},
@@ -9,23 +12,26 @@ use nih_plug_vizia::vizia::{
     views::normalized_map::amplitude_to_db,
 };
 
-/// A graph showing real-time peak information.
-pub struct PeakGraph<B>
+/// A real-time graph displaying information that is stored inside a iterable
+/// collection.
+pub struct Graph<L, I>
 where
-    B: Lens<Target = Arc<Mutex<PeakBuffer<f32>>>>,
+    L: Lens<Target = Arc<Mutex<I>>>,
+    I: Len + Index<usize, Output = f32>,
 {
-    buffer: B,
+    buffer: L,
     display_range: (f32, f32),
     scale_by_db: bool,
 }
 
-impl<B> PeakGraph<B>
+impl<L, I> Graph<L, I>
 where
-    B: Lens<Target = Arc<Mutex<PeakBuffer<f32>>>>,
+    L: Lens<Target = Arc<Mutex<I>>>,
+    I: Len + Index<usize, Output = f32> + 'static,
 {
     pub fn new(
         cx: &mut Context,
-        buffer: B,
+        buffer: L,
         display_range: impl Res<(f32, f32)>,
         scale_by_db: impl Res<bool>,
     ) -> Handle<Self> {
@@ -38,9 +44,10 @@ where
     }
 }
 
-impl<B> View for PeakGraph<B>
+impl<L, I> View for Graph<L, I>
 where
-    B: Lens<Target = Arc<Mutex<PeakBuffer<f32>>>>,
+    L: Lens<Target = Arc<Mutex<I>>>,
+    I: Len + Index<usize, Output = f32> + 'static,
 {
     fn element(&self) -> Option<&'static str> {
         Some("22-visualizer")
@@ -59,50 +66,57 @@ where
         let mut stroke = vg::Path::new();
         let binding = self.buffer.get(cx);
         let ring_buf = &(binding.lock().unwrap());
-        let mut rb_iter = ring_buf.into_iter();
 
-        let mut i = 0.;
+        let mut i = 1;
+
         if self.scale_by_db {
-            let mut peak = (amplitude_to_db(*(rb_iter.next().unwrap())))
-                .clamp(self.display_range.0, self.display_range.1);
+            let mut peak =
+                (amplitude_to_db(ring_buf[0])).clamp(self.display_range.0, self.display_range.1);
 
             peak -= self.display_range.0;
             peak /= self.display_range.1 - self.display_range.0;
 
             stroke.move_to(x, y + h * (1. - peak));
 
-            for p in rb_iter {
+            while i < ring_buf.len() {
                 // Convert peak to decibels and clamp it in range
-                peak = (amplitude_to_db(*p)).clamp(self.display_range.0, self.display_range.1);
+                peak = (amplitude_to_db(ring_buf[i]))
+                    .clamp(self.display_range.0, self.display_range.1);
 
                 // Normalize peak's range
                 peak -= self.display_range.0;
                 peak /= self.display_range.1 - self.display_range.0;
 
                 // Draw peak as a new point
-                stroke.line_to(x + (w / ring_buf.len() as f32) * i, y + h * (1. - peak));
-                i += 1.;
+                stroke.line_to(
+                    x + (w / ring_buf.len() as f32) * i as f32,
+                    y + h * (1. - peak),
+                );
+                i += 1;
             }
         } else {
             let mut peak =
-                (*(rb_iter.next().unwrap())).clamp(self.display_range.0, self.display_range.1);
+                (amplitude_to_db(ring_buf[0])).clamp(self.display_range.0, self.display_range.1);
 
             peak -= self.display_range.0;
             peak /= self.display_range.1 - self.display_range.0;
 
             stroke.move_to(x, y + h * (1. - peak));
 
-            for peak in rb_iter {
+            while i < ring_buf.len() {
                 // Clamp peak in range
-                let mut peak = (*peak).clamp(self.display_range.0, self.display_range.1);
+                let mut peak = ring_buf[i].clamp(self.display_range.0, self.display_range.1);
 
                 // Normalize peak's range
                 peak -= self.display_range.0;
                 peak /= self.display_range.1 - self.display_range.0;
 
                 // Draw peak as a new point
-                stroke.line_to(x + (w / ring_buf.len() as f32) * i, y + h * (1. - peak));
-                i += 1.;
+                stroke.line_to(
+                    x + (w / ring_buf.len() as f32) * i as f32,
+                    y + h * (1. - peak),
+                );
+                i += 1;
             }
         }
 

--- a/src/visualizers/mod.rs
+++ b/src/visualizers/mod.rs
@@ -1,13 +1,13 @@
 //! Views which visualize the audio running through your plug-in.
 
+mod graph;
 mod grid;
 mod oscilloscope;
-mod peak_graph;
 mod unit_ruler;
 mod waveform;
 
+pub use graph::*;
 pub use grid::*;
 pub use oscilloscope::*;
-pub use peak_graph::*;
 pub use unit_ruler::*;
 pub use waveform::*;


### PR DESCRIPTION
Changes:
  - Implement `len_trait::len::Len` for all current buffers.
  - Rename `PeakGraph` to just `Graph`.
  - Make `Graph` use indexes and `len()` instead of the iterator pattern.
  - Introduce a new Enum, `ValueScaling`, which abstracts over the logic of various scaling types
  - Base `Graph` on `ValueScaling`.

This resolves #28