### PR TITLE
New grid system

### DIFF
--- a/examples/visualizers/src/editor.rs
+++ b/examples/visualizers/src/editor.rs
@@ -69,6 +69,26 @@ pub(crate) fn create(editor_data: Data, editor_state: Arc<ViziaState>) -> Option
 
 fn spectrum_analyzer(cx: &mut Context) {
     ZStack::new(cx, |cx| {
+        Grid::new(
+            cx,
+            ValueScaling::Frequency,
+            (10., 21_000.),
+            vec![
+                20., 40., 30., 50., 60., 70., 80., 90., 100., 200., 300., 400., 500., 600., 700.,
+                800., 900., 1_000., 2_000., 3_000., 4_000., 5_000., 6_000., 7_000., 8_000., 9_000.,
+                10_000., 20_000.,
+            ],
+            Orientation::Vertical,
+        )
+        .color(Color::rgb(60, 60, 60));
+        Grid::new(
+            cx,
+            ValueScaling::Linear,
+            (-80., 6.),
+            vec![0., -10., -20., -30., -40., -50., -60., -70.],
+            Orientation::Horizontal,
+        )
+        .color(Color::rgb(40, 40, 40));
         SpectrumAnalyzer::new(
             cx,
             Data::spectrum,
@@ -127,9 +147,10 @@ fn peak_graph(cx: &mut Context) {
         ZStack::new(cx, |cx| {
             Grid::new(
                 cx,
-                (-32.0, 8.0),
-                0.0,
+                ValueScaling::Linear,
+                (-32., 8.),
                 vec![6.0, 0.0, -6.0, -12.0, -18.0, -24.0, -30.0],
+                Orientation::Horizontal,
             )
             .color(Color::rgb(60, 60, 60));
 
@@ -175,8 +196,22 @@ fn peak_graph(cx: &mut Context) {
 /// Draws an oscilloscope with a grid backdrop.
 fn oscilloscope(cx: &mut Context) {
     ZStack::new(cx, |cx| {
-        Grid::new(cx, (-1.2, 1.2), 10.0, vec![0.0, 0.5, -0.5, 1.0, -1.0])
-            .color(Color::rgb(60, 60, 60));
+        Grid::new(
+            cx,
+            ValueScaling::Linear,
+            (-10., 0.),
+            vec![-1., -2., -3., -4., -5., -6., -7., -8., -9.],
+            Orientation::Vertical,
+        )
+        .color(Color::rgb(60, 60, 60));
+        Grid::new(
+            cx,
+            ValueScaling::Linear,
+            (-1.2, 1.2),
+            vec![0.0, 0.5, -0.5, 1., -1.],
+            Orientation::Horizontal,
+        )
+        .color(Color::rgb(40, 40, 40));
         Oscilloscope::new(
             cx,
             Data::oscilloscope_buffer,


### PR DESCRIPTION
# Overview

Makes the `Grid` more versatile and customizable by allowing custom scaling and orientation.

# Breaking Change

This PR introduces a **breaking change** as it changes the parameter list for `Grid::new()`. The new grid system works a bit differently from the old one in that grids are limited to being **either** vertically **or** horizontally aligned.

If you previously had a grid with only horizontal lines, like so:
```rust
Grid::new(
    cx,
    (-32.0, 8.0),
    0.0,
    vec![6.0, 0.0, -6.0, -12.0, -18.0, -24.0, -30.0],
);
```

You will now have to declare it like this:

```rust
Grid::new(
    cx,
    ValueScaling::Linear,
    (-32., 8.),
    vec![6.0, 0.0, -6.0, -12.0, -18.0, -24.0, -30.0],
    Orientation::Horizontal,
);
```

You will also have to layer two `Grid`s to get both vertical and horizontal grid lines.

# Example

This new system, although slightly more tedious to work with, grants you more control when it comes to the layout, scaling, and style of your grids. For example, here's the spectrum analyzer's grid from the `visualizers` example.

```rust
ZStack::new(cx, |cx| {
  Grid::new(
    cx,
    ValueScaling::Frequency,
    (10., 21_000.),
    vec![
        20., 40., 30., 50., 60., 70., 80., 90., 100., 200., 300., 400., 500., 600., 700.,
        800., 900., 1_000., 2_000., 3_000., 4_000., 5_000., 6_000., 7_000., 8_000., 9_000.,
        10_000., 20_000.,
    ],
    Orientation::Vertical,
  )
  .color(Color::rgb(60, 60, 60));
  
  Grid::new(
    cx,
    ValueScaling::Linear,
    (-80., 6.),
    vec![0., -10., -20., -30., -40., -50., -60., -70.],
    Orientation::Horizontal,
  )
  .color(Color::rgb(40, 40, 40));
  SpectrumAnalyzer::new(...);
}
```

- The **first** grid shows grid lines for each of the supplied **frequencies** (20Hz, 40Hz, ..., 20000Hz)
   - It's scaled logarithmically through `ValueScaling::Frequency`
   - It's vertically oriented
   - It's normalized to the range between 10 and 21 000 Hz

- The **second** grid shows grid lines for each of the supplied **magnitudes** (0dB, -10dB, ..., -70dB)
   - It's scaled linearly through `ValueScaling::Linear`
   - It's horizontally oriented
   - It's normalized to the range between -80dB and 6dB

The magnitude grid is also more faint than the frequency grid. They're in a `ZStack`, above the `SpectrumAnalyzer`.