### PR TITLE
Value-scaled UnitRuler

### DIFF
--- a/examples/visualizers/src/editor.rs
+++ b/examples/visualizers/src/editor.rs
@@ -102,6 +102,37 @@ fn spectrum_analyzer(cx: &mut Context) {
         )
         .color(Color::rgba(255, 255, 255, 160))
         .background_color(Color::rgba(255, 255, 255, 60));
+        // Displays a fade to the background color at the bottom, as a backdrop for the unit ruler
+        Element::new(cx)
+            .background_gradient(
+                LinearGradientBuilder::with_direction("to bottom")
+                    .add_stop(Color::transparent())
+                    .add_stop(Color::rgb(16, 16, 16)),
+            )
+            .height(Pixels(48.))
+            .top(Stretch(1.));
+        UnitRuler::new(
+            cx,
+            (10., 21_000.),
+            ValueScaling::Frequency,
+            vec![
+                (20., "20"),
+                (50., "50"),
+                (100., "100"),
+                (200., "200"),
+                (500., "500"),
+                (1_000., "1k"),
+                (2_000., "2k"),
+                (5_000., "5k"),
+                (10_000., "10k"),
+            ],
+            Orientation::Horizontal,
+        )
+        .height(Pixels(16.))
+        .font_size(12.)
+        .color(Color::rgb(160, 160, 160))
+        .top(Stretch(1.))
+        .bottom(Pixels(8.));
     })
     .background_color(Color::rgb(16, 16, 16))
     .border_color(Color::rgb(80, 80, 80))

--- a/examples/visualizers/src/editor.rs
+++ b/examples/visualizers/src/editor.rs
@@ -67,6 +67,7 @@ pub(crate) fn create(editor_data: Data, editor_state: Arc<ViziaState>) -> Option
     })
 }
 
+// Draws a spectrum analyzer with a grid backdrop and a frequency ruler.
 fn spectrum_analyzer(cx: &mut Context) {
     ZStack::new(cx, |cx| {
         Grid::new(
@@ -164,6 +165,7 @@ fn peak_graph(cx: &mut Context) {
         UnitRuler::new(
             cx,
             (-32.0, 8.0),
+            ValueScaling::Linear,
             vec![
                 (6.0, "6db"),
                 (0.0, "0db"),

--- a/src/visualizers/unit_ruler.rs
+++ b/src/visualizers/unit_ruler.rs
@@ -1,4 +1,5 @@
 use nih_plug_vizia::vizia::prelude::*;
+use crate::utils::ValueScaling;
 
 /// A generic ruler.
 pub struct UnitRuler {}
@@ -7,6 +8,7 @@ impl UnitRuler {
     pub fn new<'a>(
         cx: &mut Context,
         display_range: impl Res<(f32, f32)>,
+        scaling: ValueScaling,
         values: impl Res<Vec<(f32, &'static str)>>,
         orientation: Orientation,
     ) -> Handle<Self> {
@@ -16,13 +18,8 @@ impl UnitRuler {
                 .get_val(cx)
                 .into_iter()
                 .map(|v| {
-                    // Clamp
-                    let mut value = v.0.clamp(display_range.0, display_range.1);
-                    // Normalize
-                    value -= display_range.0;
-                    value /= display_range.1 - display_range.0;
-
-                    (value, v.1)
+                    // Normalize the value according to the provided scaling, within the provided range
+                    (scaling.value_to_normalized(v.0, display_range.0, display_range.1), v.1)
                 })
                 .collect::<Vec<(f32, &'static str)>>();
             ZStack::new(cx, |cx| {

--- a/src/visualizers/unit_ruler.rs
+++ b/src/visualizers/unit_ruler.rs
@@ -1,5 +1,5 @@
-use nih_plug_vizia::vizia::prelude::*;
 use crate::utils::ValueScaling;
+use nih_plug_vizia::vizia::prelude::*;
 
 /// A generic ruler.
 pub struct UnitRuler {}
@@ -19,7 +19,10 @@ impl UnitRuler {
                 .into_iter()
                 .map(|v| {
                     // Normalize the value according to the provided scaling, within the provided range
-                    (scaling.value_to_normalized(v.0, display_range.0, display_range.1), v.1)
+                    (
+                        scaling.value_to_normalized(v.0, display_range.0, display_range.1),
+                        v.1,
+                    )
                 })
                 .collect::<Vec<(f32, &'static str)>>();
             ZStack::new(cx, |cx| {


### PR DESCRIPTION
Allows custom scaling of the `UnitRuler`.

# Breaking Change

This PR introduces a **breaking change** as it changes the parameter list for `UnitRuler::new()`. Here's how to adapt a grid to this new system (from the peak graph in the `visualizers` example)

```diff
UnitRuler::new(
    cx,
    (-32.0, 8.0),
+   ValueScaling::Linear,
    vec![
        (6.0, "6db"),
        (0.0, "0db"),
        (-6.0, "-6db"),
        (-12.0, "-12db"),
        (-18.0, "-18db"),
        (-24.0, "-24db"),
        (-30.0, "-30db"),
    ],
    Orientation::Vertical,
);
```