### PR TITLE
Peak Buffer decay

### DIFF
--- a/examples/visualizers/src/lib.rs
+++ b/examples/visualizers/src/lib.rs
@@ -36,7 +36,7 @@ impl Default for VisualizersDemo {
         Self {
             params: Arc::new(DemoParams::default()),
             oscilloscope_buffer: Arc::new(Mutex::new(WaveformBuffer::new(800, 44100.0, 5.0))),
-            peak_buffer: Arc::new(Mutex::new(PeakBuffer::new(800, 44100.0, 10.0))),
+            peak_buffer: Arc::new(Mutex::new(PeakBuffer::new(800, 10.0, 50.))),
             lissajous_buffer: Arc::new(Mutex::new(RingBuffer::new(2048))),
 
             spectrum_input,

--- a/src/utils/buffers/ring_buffer.rs
+++ b/src/utils/buffers/ring_buffer.rs
@@ -96,6 +96,10 @@ impl<T: Default + Copy> RingBuffer<T> {
         self.head = (self.head + 1) % self.size;
     }
 
+    pub fn peek(self: &Self) -> T {
+        self.data[(self.size + self.head - 1) % self.size]
+    }
+
     /// Clears the entire buffer, filling it with default values (usually 0)
     pub fn clear(self: &mut Self) {
         self.data.iter_mut().for_each(|x| *x = T::default());
@@ -270,5 +274,21 @@ mod tests {
         rb.enqueue(3);
 
         rb[4];
+    }
+
+    #[test]
+    fn peek() {
+        let mut rb = RingBuffer::<i32>::new(4);
+
+        rb.enqueue(1);
+        assert_eq!(rb.peek(), 1);
+        rb.enqueue(2);
+        rb.enqueue(3);
+        assert_eq!(rb.peek(), 3);
+        rb.enqueue(4);
+        rb.enqueue(5);
+        rb.enqueue(6);
+        rb.enqueue(7);
+        assert_eq!(rb.peek(), 7);
     }
 }


### PR DESCRIPTION
Implements decay for the peak buffer.

Changes the peak buffer's enqueueing behavior; It now behaves like a peak meter, by immediately snapping to values greater than its previous value, but decaying in amplitude if the current value is less than the previous one.

**Changes:**

- Adds `peek()` method to the `RingBuffer`
- Adds decay and decay weight fields to the `PeakBuffer`
- Adds `update()` method to the `PeakBuffer`, for updating both the sample delta and decay weight
- The `PeakBuffer`'s sample rate is now left uninitialized until `set_sample_rate` is called.

# Breaking Change

The parameter list for `PeakBuffer::new()` has now changed:

```diff
- fn new(size: usize, sample_rate: f32, duration: f32)
+ fn new(size: usize, duration:    f32, decay:    f32)
```

As an example, this is how you could adapt to this new parameter list if you have a `PeakBuffer` that you initialize inside your plug-in's `default()` function.

```diff
impl Default for DemoPlugin {
    fn default() -> Self {
        Self {
-           peak_buffer: Arc::new(Mutex::new(PeakBuffer::new(800, 44100.0, 10.0)))
+           peak_buffer: Arc::new(Mutex::new(PeakBuffer::new(800, 10.0, 0.)))
        }
    }
}
```