### PR TITLE
Allow range to be bound to application data

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -66,6 +66,32 @@ impl ValueScaling {
         }
         .clamp(0., 1.)
     }
+
+    pub fn value_to_normalized_optional(&self, value: f32, min: f32, max: f32) -> Option<f32> {
+        let unmap = |x: f32| -> f32 { (x - min) / (max - min) };
+
+        let value = match self {
+            ValueScaling::Linear => unmap(value),
+
+            ValueScaling::Power(exponent) => unmap(value).powf(1.0 / *exponent),
+
+            ValueScaling::Frequency => {
+                let minl = min.log2();
+                let range = max.log2() - minl;
+                (value.log2() - minl) / range
+            }
+
+            ValueScaling::Decibels => unmap({
+                const CONVERSION_FACTOR: f32 = std::f32::consts::LOG10_E * 20.0;
+                value.ln() * CONVERSION_FACTOR
+            }),
+        };
+        if (0.0..=1.0).contains(&value) {
+            Some(value)
+        } else {
+            None
+        }
+    }
 }
 
 // We can't use impl_res_simple!() since we're using nih_plug's version of VIZIA

--- a/src/visualizers/grid.rs
+++ b/src/visualizers/grid.rs
@@ -41,6 +41,7 @@ pub struct Grid {
 
 enum GridEvents {
     UpdateRange((f32, f32)),
+    UpdateScaling(ValueScaling),
 }
 
 impl Grid {
@@ -59,6 +60,7 @@ impl Grid {
         }
         .build(cx, |_| {})
         .range(range)
+        .scaling(scaling)
     }
 }
 
@@ -116,13 +118,10 @@ impl View for Grid {
             &vg::Paint::color(cx.font_color().into()).with_line_width(line_width),
         );
     }
-    fn event(
-        &mut self,
-        _cx: &mut nih_plug_vizia::vizia::context::EventContext,
-        event: &mut nih_plug_vizia::vizia::events::Event,
-    ) {
+    fn event(&mut self, _cx: &mut EventContext, event: &mut Event) {
         event.map(|e, _| match e {
             GridEvents::UpdateRange(v) => self.range = *v,
+            GridEvents::UpdateScaling(v) => self.scaling = *v,
         });
     }
 }
@@ -133,6 +132,15 @@ impl<'a> RangeModifiers for Handle<'a, Grid> {
 
         range.set_or_bind(self.context(), e, move |cx, r| {
             (*cx).emit_to(e, GridEvents::UpdateRange(r.clone()));
+        });
+
+        self
+    }
+    fn scaling(mut self, scaling: impl Res<ValueScaling>) -> Self {
+        let e = self.entity();
+
+        scaling.set_or_bind(self.context(), e, move |cx, s| {
+            (*cx).emit_to(e, GridEvents::UpdateScaling(s));
         });
 
         self

--- a/src/visualizers/meter.rs
+++ b/src/visualizers/meter.rs
@@ -1,9 +1,8 @@
 use std::sync::{Arc, Mutex};
 
-use crate::prelude::FillModifiers;
 use nih_plug_vizia::vizia::{prelude::*, vg};
 
-use super::{FillFrom, RangeModifiers};
+use super::{FillFrom, FillModifiers, RangeModifiers};
 use crate::utils::ValueScaling;
 use crate::utils::VisualizerBuffer;
 

--- a/src/visualizers/meter.rs
+++ b/src/visualizers/meter.rs
@@ -57,11 +57,13 @@ where
         }
         .build(cx, |_| {})
         .range(range)
+        .scaling(scaling)
     }
 }
 
 enum MeterEvents {
     UpdateRange((f32, f32)),
+    UpdateScaling(ValueScaling),
 }
 
 impl<L, I> View for Meter<L, I>
@@ -144,6 +146,7 @@ where
     fn event(&mut self, _cx: &mut EventContext, event: &mut Event) {
         event.map(|e, _| match e {
             MeterEvents::UpdateRange(v) => self.range = *v,
+            MeterEvents::UpdateScaling(v) => self.scaling = *v,
         });
     }
 }
@@ -207,6 +210,15 @@ where
 
         range.set_or_bind(self.context(), e, move |cx, r| {
             (*cx).emit_to(e, MeterEvents::UpdateRange(r));
+        });
+
+        self
+    }
+    fn scaling(mut self, scaling: impl Res<ValueScaling>) -> Self {
+        let e = self.entity();
+
+        scaling.set_or_bind(self.context(), e, move |cx, s| {
+            (*cx).emit_to(e, MeterEvents::UpdateScaling(s));
         });
 
         self

--- a/src/visualizers/mod.rs
+++ b/src/visualizers/mod.rs
@@ -23,3 +23,17 @@ use nih_plug_vizia::vizia::binding::Res;
 pub trait RangeModifiers {
     fn range(self, range: impl Res<(f32, f32)>) -> Self;
 }
+
+pub(crate) enum FillFrom {
+    Top,
+    Bottom,
+    Value(f32),
+}
+
+pub trait FillModifiers {
+    /// Allows for the view to be filled from the max instead of the min value.
+    fn fill_from_max(self) -> Self;
+
+    /// Allows for the view to be filled from any desired level.
+    fn fill_from_value(self, level: f32) -> Self;
+}

--- a/src/visualizers/mod.rs
+++ b/src/visualizers/mod.rs
@@ -17,3 +17,9 @@ pub use oscilloscope::*;
 pub use spectrum_analyzer::*;
 pub use unit_ruler::*;
 pub use waveform::*;
+
+use nih_plug_vizia::vizia::binding::Res;
+
+pub trait RangeModifiers {
+    fn range(self, range: impl Res<(f32, f32)>) -> Self;
+}

--- a/src/visualizers/mod.rs
+++ b/src/visualizers/mod.rs
@@ -18,10 +18,18 @@ pub use spectrum_analyzer::*;
 pub use unit_ruler::*;
 pub use waveform::*;
 
+use super::utils::ValueScaling;
 use nih_plug_vizia::vizia::binding::Res;
 
 pub trait RangeModifiers {
+    /// Sets the minimum and maximum values that can be displayed by the view
+    ///
+    /// The values are relative to the scaling - e.g. for peak volume information,
+    /// `(-48., 6.)` would be -48 to +6 dB when the scaling is set to
+    /// [`ValueScaling::Decibels`]
     fn range(self, range: impl Res<(f32, f32)>) -> Self;
+    /// Specifies what scaling the view should use
+    fn scaling(self, scaling: impl Res<ValueScaling>) -> Self;
 }
 
 pub(crate) enum FillFrom {

--- a/src/visualizers/oscilloscope.rs
+++ b/src/visualizers/oscilloscope.rs
@@ -36,6 +36,7 @@ where
 
 enum OscilloscopeEvents {
     UpdateRange((f32, f32)),
+    UpdateScaling(ValueScaling),
 }
 
 impl<B> Oscilloscope<B>
@@ -61,6 +62,7 @@ where
         }
         .build(cx, |_| {})
         .range(range)
+        .scaling(scaling)
     }
 }
 
@@ -130,6 +132,7 @@ where
     fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
         event.map(|e, _| match e {
             OscilloscopeEvents::UpdateRange(v) => self.range = *v,
+            OscilloscopeEvents::UpdateScaling(v) => self.scaling = *v,
         });
     }
 }
@@ -142,7 +145,16 @@ where
         let e = self.entity();
 
         range.set_or_bind(self.context(), e, move |cx, r| {
-            (*cx).emit_to(e, OscilloscopeEvents::UpdateRange(r.clone()));
+            (*cx).emit_to(e, OscilloscopeEvents::UpdateRange(r));
+        });
+
+        self
+    }
+    fn scaling(mut self, scaling: impl Res<ValueScaling>) -> Self {
+        let e = self.entity();
+
+        scaling.set_or_bind(self.context(), e, move |cx, s| {
+            (*cx).emit_to(e, OscilloscopeEvents::UpdateScaling(s));
         });
 
         self

--- a/src/visualizers/oscilloscope.rs
+++ b/src/visualizers/oscilloscope.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use nih_plug_vizia::vizia::{prelude::*, vg};
 
+use super::RangeModifiers;
 use crate::utils::{ValueScaling, VisualizerBuffer, WaveformBuffer};
 
 /// Waveform display for real-time input.
@@ -29,8 +30,12 @@ where
     B: Lens<Target = Arc<Mutex<WaveformBuffer>>>,
 {
     buffer: B,
-    display_range: (f32, f32),
+    range: (f32, f32),
     scaling: ValueScaling,
+}
+
+enum OscilloscopeEvents {
+    UpdateRange((f32, f32)),
 }
 
 impl<B> Oscilloscope<B>
@@ -38,7 +43,7 @@ where
     B: Lens<Target = Arc<Mutex<WaveformBuffer>>>,
 {
     /// Creates a new Oscilloscope.
-    ///    
+    ///
     /// Takes in a `buffer`, which should be used to store the peak values. You
     /// need to write to it inside your plugin code, thread-safely send it to
     /// the editor thread, and then pass it into this oscilloscope. Which is
@@ -46,15 +51,16 @@ where
     pub fn new(
         cx: &mut Context,
         buffer: B,
-        display_range: impl Res<(f32, f32)>,
+        range: impl Res<(f32, f32)>,
         scaling: impl Res<ValueScaling>,
     ) -> Handle<Self> {
         Self {
             buffer,
-            display_range: display_range.get_val(cx),
+            range: range.get_val(cx),
             scaling: scaling.get_val(cx),
         }
         .build(cx, |_| {})
+        .range(range)
     }
 }
 
@@ -81,18 +87,14 @@ where
         let width_delta = w / ring_buf.len() as f32;
 
         // Local minima (bottom part of waveform)
-        let mut py = self.scaling.value_to_normalized(
-            ring_buf[0].0,
-            self.display_range.0,
-            self.display_range.1,
-        );
+        let mut py = self
+            .scaling
+            .value_to_normalized(ring_buf[0].0, self.range.0, self.range.1);
         fill.move_to(x, y + h * (1. - py) + 1.);
         for i in 1..ring_buf.len() {
-            py = self.scaling.value_to_normalized(
-                ring_buf[i].0,
-                self.display_range.0,
-                self.display_range.1,
-            );
+            py = self
+                .scaling
+                .value_to_normalized(ring_buf[i].0, self.range.0, self.range.1);
 
             fill.line_to(x + width_delta * i as f32, y + h * (1. - py) + 1.);
         }
@@ -103,16 +105,16 @@ where
         // Local maxima (top part of waveform)
         py = self.scaling.value_to_normalized(
             ring_buf[ring_buf.len() - 1].1,
-            self.display_range.0,
-            self.display_range.1,
+            self.range.0,
+            self.range.1,
         );
         fill.line_to(x + w, y + h * (1. - py) + 1.);
         top_stroke.move_to(x + w, y + h * (1. - py) + 1.);
         for i in 1..ring_buf.len() {
             py = self.scaling.value_to_normalized(
                 ring_buf[ring_buf.len() - i].1,
-                self.display_range.0,
-                self.display_range.1,
+                self.range.0,
+                self.range.1,
             );
 
             fill.line_to(x + w - width_delta * i as f32, y + h * (1. - py) + 1.);
@@ -124,5 +126,25 @@ where
             &fill,
             &vg::Paint::color(cx.font_color().into()).with_line_width(0.),
         );
+    }
+    fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
+        event.map(|e, _| match e {
+            OscilloscopeEvents::UpdateRange(v) => self.range = *v,
+        });
+    }
+}
+
+impl<'a, B> RangeModifiers for Handle<'a, Oscilloscope<B>>
+where
+    B: Lens<Target = Arc<Mutex<WaveformBuffer>>>,
+{
+    fn range(mut self, range: impl Res<(f32, f32)>) -> Self {
+        let e = self.entity();
+
+        range.set_or_bind(self.context(), e, move |cx, r| {
+            (*cx).emit_to(e, OscilloscopeEvents::UpdateRange(r.clone()));
+        });
+
+        self
     }
 }


### PR DESCRIPTION
Allows for values, as well as lenses to be passed into the Graph, Grid, Meter and Oscilloscope.

This pull request introduces the `RangeModifiers` trait. The trait allows for the respective views to have their ranges and scalings bound to a lens, or set to a value. It is implemented for:

  - [x] Graph
  - [x] Grid
  - [x] Meter
  - [x] Oscilloscope

Also, this PR fixes some annoyances when updating the ranges of certain views.
- The `UnitRuler` hides values that are out of scope, instead of clamping them
- Graphs whose range gets bound/updated after creation will also update their fill position correctly now.

> [!CAUTION]
> This PR introduces a breaking change for graphs! If you want to fill them from a certain position, you will now have to do so by calling `fill_from_max` or `fill_from` on them.